### PR TITLE
Use a new unique bundle identifier and set the build version to 1.3.

### DIFF
--- a/FetLife.xcodeproj/project.pbxproj
+++ b/FetLife.xcodeproj/project.pbxproj
@@ -565,7 +565,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = co.bitlove.FetLife;
+				PRODUCT_BUNDLE_IDENTIFIER = co.bitlove.opensource.FetLife;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "FetLife/FetLife-Swift-Bridging-Header.h";
@@ -585,7 +585,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = co.bitlove.FetLife;
+				PRODUCT_BUNDLE_IDENTIFIER = co.bitlove.opensource.FetLife;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "FetLife/FetLife-Swift-Bridging-Header.h";

--- a/FetLife/Info.plist
+++ b/FetLife/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ These instructions are written assuming you know very little about computers and
   - Connect your iPhone to your computer.
   - Select your iPhone from the "[Scheme toolbar menu](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Art/5_launchappondevice_2x.png)".
   - Click the "Run" button.
-  - If an error occurs saying the bundle identifier is unavailable, change the bundle identifier to something unique and try again.
+  - If an error occurs saying the Bundle Identifier is unavailable, change the Bundle Identifier to something unique in Xcode and try again please.
 5. Follow the instructions in the pop up windows i.e.:
   - Click "Fix Issue".
   - Enter in the username and password for your iCloud account.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These instructions are written assuming you know very little about computers and
   - Connect your iPhone to your computer.
   - Select your iPhone from the "[Scheme toolbar menu](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Art/5_launchappondevice_2x.png)".
   - Click the "Run" button.
+  - If an error occurs saying the bundle identifier is unavailable, change the bundle identifier to something unique and try again.
 5. Follow the instructions in the pop up windows i.e.:
   - Click "Fix Issue".
   - Enter in the username and password for your iCloud account.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ These instructions are written assuming you know very little about computers and
   - `pod install`
   - `open FetLife.xcworkspace`
 4. Installing the app on your phone:
-  - Change the Bundle Identifier to something unique in Xcode.
   - Connect your iPhone to your computer.
   - Select your iPhone from the "[Scheme toolbar menu](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/Art/5_launchappondevice_2x.png)".
   - Click the "Run" button.


### PR DESCRIPTION
Hopefully if we don’t use `co.bitlove.FetLife` we can have developers all use the same bundle id. I’m not sure if it’s currently possible.